### PR TITLE
Commit 91906c7 comment addressing

### DIFF
--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -6,4 +6,5 @@ Data
 
 
 .. autofunction:: miblab.zenodo_fetch
+.. autofunction:: miblab.data.osf_fetch
    

--- a/docs/source/reference/data.rst
+++ b/docs/source/reference/data.rst
@@ -6,5 +6,5 @@ Data
 
 
 .. autofunction:: miblab.zenodo_fetch
-.. autofunction:: miblab.data.osf_fetch
+.. autofunction:: miblab.osf_fetch
    

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ name = "miblab"
 version = "0.0.5"
 dependencies = [
   'importlib-resources>=1.1.0',
+  'tqdm', 
 ]
 # optional information
 description = "Resources of the open laboratory for medical imaging biomarkers"
@@ -52,6 +53,7 @@ report = [
 ]
 data = [
   'requests',
+  'osfclient', 
 ]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ importlib-resources>=1.1.0
 pylatex
 requests
 osfclient
+tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 importlib-resources>=1.1.0
 pylatex
 requests
+osfclient

--- a/src/miblab/data.py
+++ b/src/miblab/data.py
@@ -6,6 +6,18 @@ try:
 except:
     import_error = True
 
+try:
+    from osfclient.api import OSF
+except ImportError:
+    OSF = None
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = None
+
+import zipfile
+
 # Zenodo DOI of the repository
 # DOIs need to be updated when new versions are created
 DOI = {
@@ -28,7 +40,7 @@ DATASETS = {
 }
 
 
-def zenodo_fetch(dataset:str, folder:str, doi:str=None, filename:str=None):
+def zenodo_fetch(dataset: str, folder: str, doi: str = None, filename: str = None):
     """Download a dataset from Zenodo
 
     Args:
@@ -53,7 +65,7 @@ def zenodo_fetch(dataset:str, folder:str, doi:str=None, filename:str=None):
     if import_error:
         raise NotImplementedError(
             'Please install miblab as pip install miblab[data]'
-            'to use this function.'
+            ' to use this function.'
         )
     
     # Get DOI
@@ -105,3 +117,95 @@ def zenodo_fetch(dataset:str, folder:str, doi:str=None, filename:str=None):
         f.write(file_response.content)
 
     return file
+
+
+def osf_fetch(project_id: str, folder: str, path: list = [], token: str = None, extract: bool = True, verbose: bool = True):
+    """Download a dataset from OSF (Open Science Framework)
+
+    Args:
+        project_id (str): OSF project ID (e.g., 'un5ct')
+        folder (str): Local folder where to save the dataset
+        path (list, optional): Subfolders inside project (default empty)
+        token (str, optional): Personal OSF token if private access needed
+        extract (bool, optional): Whether to unzip .zip files (default True)
+        verbose (bool, optional): Whether to print progress (default True)
+
+    Raises:
+        ImportError: If osfclient or tqdm not installed
+        FileNotFoundError: If folder not found
+
+    Example (public project):
+        >>> from miblab.data import osf_fetch
+        >>> osf_fetch(
+        ...     project_id='un5ct',
+        ...     folder='/path/to/save',
+        ...     path=['TRISTAN', 'RAT', 'bosentan_highdose', 'Sanofi', 'Day_1']
+        ... )
+
+    Example (private project with token):
+        >>> from miblab.data import osf_fetch
+        >>> osf_fetch(
+        ...     project_id='abcde',
+        ...     folder='/path/to/save',
+        ...     token='your-osf-access-token',
+        ...     path=['private', 'dataset', 'folder']
+        ... )
+
+    """
+    if OSF is None:
+        raise ImportError("Please install osfclient: pip install osfclient")
+    if tqdm is None:
+        raise ImportError("Please install tqdm: pip install tqdm")
+
+    os.makedirs(folder, exist_ok=True)
+
+    osf = OSF(token=token)
+    project = osf.project(project_id)
+    storage = project.storage('osfstorage')
+
+    current = storage
+    for part in path:
+        for f in current.folders:
+            if f.name == part:
+                current = f
+                break
+        else:
+            raise FileNotFoundError(f"Folder '{part}' not found in {'/'.join(path)}")
+
+    def download(current_folder, local_folder):
+        os.makedirs(local_folder, exist_ok=True)
+        for file in current_folder.files:
+            local_file = os.path.join(local_folder, file.name)
+            print(f"Downloading {file.name}...")
+            try:
+                with open(local_file, 'wb') as f:
+                    file.write_to(f)
+            except Exception as e:
+                print(f"Warning downloading {file.name}: {e}")
+
+        for subfolder in current_folder.folders:
+            download(subfolder, os.path.join(local_folder, subfolder.name))
+
+    download(current, folder)
+
+    if extract:
+        for dirpath, _, filenames in os.walk(folder):
+            for filename in filenames:
+                if filename.lower().endswith('.zip'):
+                    zip_path = os.path.join(dirpath, filename)
+                    extract_to = os.path.join(dirpath, filename[:-4])
+                    os.makedirs(extract_to, exist_ok=True)
+                    try:
+                        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+                            bad_file = zip_ref.testzip()
+                            if bad_file:
+                                raise zipfile.BadZipFile(f"Corrupt file {bad_file} inside {zip_path}")
+                            zip_ref.extractall(extract_to)
+                        os.remove(zip_path)
+                        if verbose:
+                            print(f"Unzipped and deleted {zip_path}")
+                    except Exception as e:
+                        if verbose:
+                            print(f"Warning unzipping {zip_path}: {e}")
+
+    return folder

--- a/src/miblab/data.py
+++ b/src/miblab/data.py
@@ -108,7 +108,7 @@ def zenodo_fetch(dataset:str, folder:str, doi:str=None, filename:str=None):
 
     return file
 
-def osf_fetch(dataset: str, folder: str, project_id: str = "un5ct", token: str = None, extract: bool = True, verbose: bool = True):
+def osf_fetch(dataset: str, folder: str, project: str = "un5ct", token: str = None, extract: bool = True, verbose: bool = True):
     """
     Download a dataset from OSF (Open Science Framework).
 
@@ -118,7 +118,7 @@ def osf_fetch(dataset: str, folder: str, project_id: str = "un5ct", token: str =
     Args:
         dataset (str): Subfolder path inside the OSF project. If an empty string, all files in the root will be downloaded (use with caution).
         folder (str): Local folder where the dataset will be saved.
-        project_id (str, optional): OSF project ID (default is "un5ct").
+        project (str, optional): OSF project ID (default is "un5ct").
         token (str, optional): Personal OSF token for accessing private projects. Read from OSF_TOKEN environment variable if needed.
         extract (bool, optional): Whether to automatically unzip downloaded .zip files (default is True).
         verbose (bool, optional): Whether to print progress messages (default is True).
@@ -131,7 +131,7 @@ def osf_fetch(dataset: str, folder: str, project_id: str = "un5ct", token: str =
         str: Path to the local folder containing the downloaded data.
 
     Example:
-        >>> from miblab.data import osf_fetch
+        >>> from miblab import osf_fetch
         >>> osf_fetch('TRISTAN/RAT/bosentan_highdose/Sanofi', 'test_download')
     """
     if import_error:
@@ -144,7 +144,7 @@ def osf_fetch(dataset: str, folder: str, project_id: str = "un5ct", token: str =
 
     # Connect to OSF and locate project storage
     osf = OSF(token=token)  #osf = OSF()  for public projects
-    project = osf.project(project_id)
+    project = osf.project(project)
     storage = project.storage('osfstorage')
 
     # Navigate the dataset folder if provided

--- a/src/miblab/data.py
+++ b/src/miblab/data.py
@@ -108,16 +108,31 @@ def zenodo_fetch(dataset:str, folder:str, doi:str=None, filename:str=None):
 
     return file
 
-def osf_fetch(folder: str, dataset: str = "", project_id: str = "un5ct", token: str = None, extract: bool = True, verbose: bool = True):
-    """Download a dataset from OSF (Open Science Framework).
+def osf_fetch(dataset: str, folder: str, project_id: str = "un5ct", token: str = None, extract: bool = True, verbose: bool = True):
+    """
+    Download a dataset from OSF (Open Science Framework).
+
+    This function downloads a specific dataset (folder or subfolder) from a public or private OSF project.
+    Files are saved into the specified local directory. If a zip file is found, it will be extracted by default.
 
     Args:
-        folder (str): Local folder where to save the dataset
-        dataset (str, optional): Subfolder path inside project (default "")
-        project_id (str, optional): OSF project ID (default "un5ct")
-        token (str, optional): Personal OSF token if private access needed
-        extract (bool, optional): Whether to unzip .zip files (default True)
-        verbose (bool, optional): Whether to print progress (default True)
+        dataset (str): Subfolder path inside the OSF project. If an empty string, all files in the root will be downloaded (use with caution).
+        folder (str): Local folder where the dataset will be saved.
+        project_id (str, optional): OSF project ID (default is "un5ct").
+        token (str, optional): Personal OSF token for accessing private projects. Read from OSF_TOKEN environment variable if needed.
+        extract (bool, optional): Whether to automatically unzip downloaded .zip files (default is True).
+        verbose (bool, optional): Whether to print progress messages (default is True).
+
+    Raises:
+        FileNotFoundError: If the specified dataset path does not exist in the OSF project.
+        NotImplementedError: If required packages are not installed.
+
+    Returns:
+        str: Path to the local folder containing the downloaded data.
+
+    Example:
+        >>> from miblab.data import osf_fetch
+        >>> osf_fetch('TRISTAN/RAT/bosentan_highdose/Sanofi', 'test_download')
     """
     if import_error:
         raise NotImplementedError(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -26,7 +26,7 @@ def test_osf_fetch():
     # Leave folder for inspection (optional)
     print(f"Test passed. Downloaded files are in: {folder}")
     # To auto-cleanup after the test, uncomment below:
-    # shutil.rmtree(folder)
+    shutil.rmtree(folder)
 
 if __name__ == "__main__":
     test_osf_fetch()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -6,7 +6,7 @@ def test_osf_fetch():
     # Set test parameters
     dataset = "TRISTAN/RAT/bosentan_highdose/Sanofi"  # Example dataset
     folder = "test_download"
-    project_id = "un5ct"  # Public OSF project
+    project = "un5ct"  # Public OSF project
     token = os.getenv('OSF_TOKEN')  # Optional: for private projects
 
     # Clean up before test
@@ -16,7 +16,7 @@ def test_osf_fetch():
     # Run osf_fetch
     try:
         print(f"Testing osf_fetch with dataset='{dataset}' and token={'provided' if token else 'not provided'}")
-        osf_fetch(dataset=dataset, folder=folder, project_id=project_id, token=token, extract=True, verbose=True)
+        osf_fetch(dataset=dataset, folder=folder, project=project, token=token, extract=True, verbose=True)
     except Exception as e:
         assert False, f"osf_fetch raised an exception: {e}"
 
@@ -28,6 +28,7 @@ def test_osf_fetch():
     print(f"Test passed. Downloaded files are in: {folder}")
     # To auto-cleanup after the test, uncomment below:
     # shutil.rmtree(folder)
+
 
 if __name__ == "__main__":
     test_osf_fetch()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,10 +4,9 @@ from miblab import osf_fetch  # Updated import path per review
 
 def test_osf_fetch():
     # Set test parameters
-    dataset = "TRISTAN/RAT/bosentan_highdose/Sanofi"  # Example dataset
+    dataset = "Challenge_Guideline"  # Example dataset
     folder = "test_download"
-    project = "un5ct"  # Public OSF project
-    token = os.getenv('OSF_TOKEN')  # Optional: for private projects
+    project_id = "u7a6f"  # Public OSF project
 
     # Clean up before test
     if os.path.exists(folder):
@@ -15,8 +14,8 @@ def test_osf_fetch():
 
     # Run osf_fetch
     try:
-        print(f"Testing osf_fetch with dataset='{dataset}' and token={'provided' if token else 'not provided'}")
-        osf_fetch(dataset=dataset, folder=folder, project=project, token=token, extract=True, verbose=True)
+        print(f"Testing osf_fetch with dataset='{dataset}' from public OSF project '{project_id}'")
+        osf_fetch(dataset=dataset, folder=folder, project=project_id, extract=True, verbose=True)
     except Exception as e:
         assert False, f"osf_fetch raised an exception: {e}"
 
@@ -28,7 +27,6 @@ def test_osf_fetch():
     print(f"Test passed. Downloaded files are in: {folder}")
     # To auto-cleanup after the test, uncomment below:
     # shutil.rmtree(folder)
-
 
 if __name__ == "__main__":
     test_osf_fetch()

--- a/tests/test_osf_fetch.py
+++ b/tests/test_osf_fetch.py
@@ -1,39 +1,33 @@
 import os
 import shutil
-from miblab.data import osf_fetch
+from miblab import osf_fetch  # Updated import path per review
 
 def test_osf_fetch():
     # Set test parameters
+    dataset = "TRISTAN/RAT/bosentan_highdose/Sanofi"  # Example dataset
     folder = "test_download"
-    dataset = "TRISTAN/RAT/bosentan_highdose/Sanofi"  # If empty, will download everything
-    project_id = "un5ct"  # Public project for default test
+    project_id = "un5ct"  # Public OSF project
+    token = os.getenv('OSF_TOKEN')  # Optional: for private projects
 
-    # Optional: Token for private project test
-    token = os.getenv('OSF_TOKEN')  # Read token from environment variable if available
-
-    # Clean up before running
+    # Clean up before test
     if os.path.exists(folder):
         shutil.rmtree(folder)
 
     # Run osf_fetch
     try:
-        print(f"Testing osf_fetch with dataset '{dataset}' (token={'provided' if token else 'not provided'})...")
-        osf_fetch(folder=folder, dataset=dataset, project_id=project_id, token=token, extract=True, verbose=True)
+        print(f"Testing osf_fetch with dataset='{dataset}' and token={'provided' if token else 'not provided'}")
+        osf_fetch(dataset=dataset, folder=folder, project_id=project_id, token=token, extract=True, verbose=True)
     except Exception as e:
-        print(f"Test failed with error: {e}")
-        return
+        assert False, f"osf_fetch raised an exception: {e}"
 
-    # Check that something got downloaded
-    if not os.path.exists(folder):
-        print("Test failed: folder not created.")
-    elif not any(os.scandir(folder)):
-        print("Test failed: no files downloaded.")
-    else:
-        print("Test passed: files downloaded successfully.")
+    # Assertions (pytest-compatible)
+    assert os.path.exists(folder), "Folder was not created"
+    assert any(os.scandir(folder)), "No files were downloaded"
 
-    # Clean up after test (optional: comment out if you want to inspect)
+    # Leave folder for inspection (optional)
+    print(f"Test passed. Downloaded files are in: {folder}")
+    # To auto-cleanup after the test, uncomment below:
     # shutil.rmtree(folder)
-    print(f"Test folder left at: {folder}")
 
 if __name__ == "__main__":
     test_osf_fetch()

--- a/tests/test_osf_fetch.py
+++ b/tests/test_osf_fetch.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+from miblab.data import osf_fetch
+
+def test_osf_fetch():
+    # Set test parameters
+    folder = "test_download"
+    dataset = "TRISTAN/RAT/bosentan_highdose/Sanofi"  # If empty, will download everything
+    project_id = "un5ct"  # Public project for default test
+
+    # Optional: Token for private project test
+    token = os.getenv('OSF_TOKEN')  # Read token from environment variable if available
+
+    # Clean up before running
+    if os.path.exists(folder):
+        shutil.rmtree(folder)
+
+    # Run osf_fetch
+    try:
+        print(f"Testing osf_fetch with dataset '{dataset}' (token={'provided' if token else 'not provided'})...")
+        osf_fetch(folder=folder, dataset=dataset, project_id=project_id, token=token, extract=True, verbose=True)
+    except Exception as e:
+        print(f"Test failed with error: {e}")
+        return
+
+    # Check that something got downloaded
+    if not os.path.exists(folder):
+        print("Test failed: folder not created.")
+    elif not any(os.scandir(folder)):
+        print("Test failed: no files downloaded.")
+    else:
+        print("Test passed: files downloaded successfully.")
+
+    # Clean up after test (optional: comment out if you want to inspect)
+    # shutil.rmtree(folder)
+    print(f"Test folder left at: {folder}")
+
+if __name__ == "__main__":
+    test_osf_fetch()


### PR DESCRIPTION
Hi @plaresmedima  

Thank you for that, these are the changes i made:

	•	Centralized import error handling (requests, osfclient, tqdm) using import_error flag
	•	Updated osf_fetch function to use (folder, dataset, project_id) argument order for consistency
	•	Changed dataset from list to string (e.g., "TRISTAN/RAT/bosentan_highdose/Sanofi/Day_1")
	•	If dataset="", the entire OSF project is downloaded recursively
	•	Support for partial folder downloads (e.g., downloading just "Sanofi" or "TRISTAN/RAT")
	•	Added tqdm progress bar for download progress when verbose=True
	•	Added lightweight test_osf_fetch.py to verify OSF download functionality
	•	Expanded osf_fetch docstring with clear examples for public and private projects
	•	Added minimal one-line comments before major code blocks for better readability
	•	Added .. autofunction:: miblab.data.osf_fetch to docs/source/reference/data.rst
